### PR TITLE
Add generate_flat.py and a basic test for it.

### DIFF
--- a/cdtea/generate_flat.py
+++ b/cdtea/generate_flat.py
@@ -1,0 +1,37 @@
+from cdtea import simplicial
+import random
+
+
+def generate_flat_2d_space_time(T, X):
+    st = simplicial.Triangulation()
+
+    def add_simplex(basis, **meta):
+        st.add_simplex(simplicial.DimDSimplexKey(basis=basis), **meta)
+
+    def idx(x, t):
+        # returns an index in the spacetime, corrects for overflow in space and time
+        return (t % T) * X + x % X
+
+    for t in range(T):
+        for x in range(X):
+            # new vertex (one added per iteration )
+            i = idx(x, t)
+            add_simplex({i})
+
+            # new edges (three added per vertex)
+            spatial_edge_basis = {idx(x, t), idx(t, x + 1)}
+            add_simplex(spatial_edge_basis, type=[2, 0])
+
+            past_edge_basis = {idx(x, t), idx(t + 1, x)}
+            add_simplex(past_edge_basis, type=[1, 1])
+
+            future_edge_basis = {idx(x, t), idx(t - 1, x - 1)}
+            add_simplex(future_edge_basis, type=[1, 1])
+
+            # new triangles (two added per vertex)
+            up_triangle_basis = {idx(x, t), idx(x + 1, t), idx(x + 0, t + 1)}
+            add_simplex(up_triangle_basis, type=[2, 1], dilaton=random.Random())
+
+            down_triangle_basis = {idx(x, t), idx(x + 1, t), idx(x + 1, t - 1)}
+            add_simplex(down_triangle_basis, type=[1, 2], dilaton=random.Random())
+    return st

--- a/cdtea/generate_flat.py
+++ b/cdtea/generate_flat.py
@@ -2,15 +2,16 @@ from cdtea import simplicial
 from typing import Union, FrozenSet, Set
 import random
 
+
 def generate_flat_2d_space_time(time_size: int, space_size: int) -> simplicial.Triangulation:
     """
     returns a flat 2d simplicial.Triangulation with toroidal topology consisting of
     n 0-simplices, 3n 1-simplices, and 2n 2-simplices
     where n = time_size*space_size.
 
-    Each simplex is instantiated with a "type" metadata with the convention being
-    type = [number of constituent 0-simplices in past, number of constituent 0-simplices in future]
-    0-simplices are not given a type because they all have the same type.
+    Each simplex is instantiated with a "s_type" metadata with the convention being
+    s_type = [number of constituent 0-simplices in past, number of constituent 0-simplices in future]
+    0-simplices are not given a s_type because they all have the same type.
     0-simplices are instantiated with a "t" metadata value which is a time index.
     2-simplices are instantiated with a "dilaton" metadata value, which is random.
 
@@ -38,19 +39,19 @@ def generate_flat_2d_space_time(time_size: int, space_size: int) -> simplicial.T
 
             # new edges (three added per vertex)
             spatial_edge_basis = {idx(x_idx=x, t_idx=t), idx(x_idx=x + 1, t_idx=t)}
-            add_simplex(spatial_edge_basis, type=[2, 0])
+            add_simplex(spatial_edge_basis, s_type=[2, 0])
 
             past_edge_basis = {idx(x_idx=x, t_idx=t), idx(x_idx=x, t_idx=t + 1)}
-            add_simplex(past_edge_basis, type=[1, 1])
+            add_simplex(past_edge_basis, s_type=[1, 1])
 
             future_edge_basis = {idx(x_idx=x, t_idx=t), idx(x_idx=x - 1, t_idx=t - 1)}
-            add_simplex(future_edge_basis, type=[1, 1])
+            add_simplex(future_edge_basis, s_type=[1, 1])
 
             # new triangles (two added per vertex)
             # each triangle is instantiated with a random dilaton value between zero and 1 using random.Random()
             up_triangle_basis = {idx(x_idx=x, t_idx=t), idx(x_idx=x + 1, t_idx=t), idx(x_idx=x + 0, t_idx=t + 1)}
-            add_simplex(up_triangle_basis, type=[2, 1], dilaton=random.Random())
+            add_simplex(up_triangle_basis, s_type=[2, 1], dilaton=random.Random())
 
             down_triangle_basis = {idx(x_idx=x, t_idx=t), idx(x_idx=x + 1, t_idx=t), idx(x_idx=x + 1, t_idx=t - 1)}
-            add_simplex(down_triangle_basis, type=[1, 2], dilaton=random.Random())
+            add_simplex(down_triangle_basis, s_type=[1, 2], dilaton=random.Random())
     return space_time

--- a/cdtea/generate_flat.py
+++ b/cdtea/generate_flat.py
@@ -1,37 +1,56 @@
 from cdtea import simplicial
+from typing import Union, FrozenSet, Set
 import random
 
+def generate_flat_2d_space_time(time_size: int, space_size: int) -> simplicial.Triangulation:
+    """
+    returns a flat 2d simplicial.Triangulation with toroidal topology consisting of
+    n 0-simplices, 3n 1-simplices, and 2n 2-simplices
+    where n = time_size*space_size.
 
-def generate_flat_2d_space_time(T, X):
-    st = simplicial.Triangulation()
+    Each simplex is instantiated with a "type" metadata with the convention being
+    type = [number of constituent 0-simplices in past, number of constituent 0-simplices in future]
+    0-simplices are not given a type because they all have the same type.
+    0-simplices are instantiated with a "t" metadata value which is a time index.
+    2-simplices are instantiated with a "dilaton" metadata value, which is random.
 
-    def add_simplex(basis, **meta):
-        st.add_simplex(simplicial.DimDSimplexKey(basis=basis), **meta)
+    time_size: an int specifying the number of space-like slices in the triangulation
+    space_size: an int specifying the resolution of each space-like slice
 
-    def idx(x, t):
-        # returns an index in the spacetime, corrects for overflow in space and time
-        return (t % T) * X + x % X
+    """
+    space_time = simplicial.Triangulation()
 
-    for t in range(T):
-        for x in range(X):
+    def add_simplex(basis: Union[Set, FrozenSet], **meta):
+        """shorthand for adding a simplex to the triangulation"""
+        space_time.add_simplex(simplicial.DimDSimplexKey(basis=basis), **meta)
+
+    def idx(x_idx: int, t_idx: int):
+        """shorthand for returning a unique index for a given space-time position.
+        It autocorrects for space and time overflow
+        """
+        return (t_idx % time_size) * space_size + x_idx % space_size
+
+    for t in range(time_size):
+        for x in range(space_size):
             # new vertex (one added per iteration )
-            i = idx(x, t)
-            add_simplex({i})
+            i = idx(x_idx=x, t_idx=t)
+            add_simplex({i}, t=t)
 
             # new edges (three added per vertex)
-            spatial_edge_basis = {idx(x, t), idx(t, x + 1)}
+            spatial_edge_basis = {idx(x_idx=x, t_idx=t), idx(x_idx=x + 1, t_idx=t)}
             add_simplex(spatial_edge_basis, type=[2, 0])
 
-            past_edge_basis = {idx(x, t), idx(t + 1, x)}
+            past_edge_basis = {idx(x_idx=x, t_idx=t), idx(x_idx=x, t_idx=t + 1)}
             add_simplex(past_edge_basis, type=[1, 1])
 
-            future_edge_basis = {idx(x, t), idx(t - 1, x - 1)}
+            future_edge_basis = {idx(x_idx=x, t_idx=t), idx(x_idx=x - 1, t_idx=t - 1)}
             add_simplex(future_edge_basis, type=[1, 1])
 
             # new triangles (two added per vertex)
-            up_triangle_basis = {idx(x, t), idx(x + 1, t), idx(x + 0, t + 1)}
+            # each triangle is instantiated with a random dilaton value between zero and 1 using random.Random()
+            up_triangle_basis = {idx(x_idx=x, t_idx=t), idx(x_idx=x + 1, t_idx=t), idx(x_idx=x + 0, t_idx=t + 1)}
             add_simplex(up_triangle_basis, type=[2, 1], dilaton=random.Random())
 
-            down_triangle_basis = {idx(x, t), idx(x + 1, t), idx(x + 1, t - 1)}
+            down_triangle_basis = {idx(x_idx=x, t_idx=t), idx(x_idx=x + 1, t_idx=t), idx(x_idx=x + 1, t_idx=t - 1)}
             add_simplex(down_triangle_basis, type=[1, 2], dilaton=random.Random())
-    return st
+    return space_time

--- a/cdtea/simplicial.py
+++ b/cdtea/simplicial.py
@@ -17,9 +17,14 @@ class SimplexKey:
         self._dim = dim
 
     def __repr__(self):
-        if self._dim == 0:
-            return str(list(self._basis)[0])
-        return '{' + ','.join(str(b) for b in self._basis) + '}'
+        # the zero d case was causing me some debug confusion so i removed it.
+        # if self._dim == 0:
+        #     return str(list(self._basis)[0])
+        return 'basis {' + ','.join(str(b) for b in self._basis) + '}'
+
+    @property
+    def basis_list(self):
+        return(list(self._basis))
 
     @property
     def dim(self):

--- a/cdtea/tests/test_generate_flat.py
+++ b/cdtea/tests/test_generate_flat.py
@@ -27,7 +27,7 @@ class TestGenerateFlat:
             assert counts[b] == 6
 
     def test_6_super_triangles(self):
-        """Test that each 0-simplex is contained in 6 edges"""
+        """Test that each 0-simplex is contained in 6 triangles"""
         t = generate_flat.generate_flat_2d_space_time(time_size=3, space_size=3)
         counts = defaultdict(int)
         for tri in t._simplices[2]:
@@ -58,6 +58,7 @@ class TestGenerateFlat:
             assert counts[b] == 4
 
     def test_correct_size(self):
+        """Test that generate_flat_2d_space_time(T,X) has T*X 0-simplices and 3*T*X 1-simplices"""
         space_sizes_to_test = [3, 4, 5, 6]
         time_sizes_to_test = [3, 4, 5, 6]
         for t_size in time_sizes_to_test:
@@ -66,7 +67,3 @@ class TestGenerateFlat:
                 t = generate_flat.generate_flat_2d_space_time(time_size=t_size, space_size=x_size)
                 assert len(t._simplices[0]) == n
                 assert len(t._simplices[1]) == 3 * n
-
-# test total
-
-# vertex/edge/triangle count

--- a/cdtea/tests/test_generate_flat.py
+++ b/cdtea/tests/test_generate_flat.py
@@ -7,10 +7,9 @@ class TestGenerateFlat:
     def test_create(self):
         """This test makes sure that generate_flat creates a triangulation
         """
-        t = generate_flat.generate_flat_2d_space_time(3, 3)
+        t = generate_flat.generate_flat_2d_space_time(time_size=3, space_size=3)
 
         assert isinstance(t, simplicial.Triangulation)
-
 
     # additional test ideas. Waiting to implement these until more tools for accessing simplex data have been constructed.
     # each vertex has 6 adjacent edges

--- a/cdtea/tests/test_generate_flat.py
+++ b/cdtea/tests/test_generate_flat.py
@@ -1,0 +1,20 @@
+from cdtea import simplicial
+from cdtea import generate_flat
+
+
+class TestGenerateFlat:
+
+    def test_create(self):
+        """This test makes sure that generate_flat creates a triangulation
+        """
+        t = generate_flat.generate_flat_2d_space_time(3, 3)
+
+        assert isinstance(t, simplicial.Triangulation)
+
+
+    # additional test ideas. Waiting to implement these until more tools for accessing simplex data have been constructed.
+    # each vertex has 6 adjacent edges
+    # each vertex has 6 adjacent triangles
+    # each vertex has two space-like edges
+    # each vertex has 4 time like edges (two past pointing and two future pointing)
+    # test total vertex/edge/triangle count

--- a/cdtea/tests/test_generate_flat.py
+++ b/cdtea/tests/test_generate_flat.py
@@ -1,5 +1,6 @@
 from cdtea import simplicial
 from cdtea import generate_flat
+from collections import defaultdict
 
 
 class TestGenerateFlat:
@@ -11,9 +12,61 @@ class TestGenerateFlat:
 
         assert isinstance(t, simplicial.Triangulation)
 
-    # additional test ideas. Waiting to implement these until more tools for accessing simplex data have been constructed.
-    # each vertex has 6 adjacent edges
-    # each vertex has 6 adjacent triangles
-    # each vertex has two space-like edges
-    # each vertex has 4 time like edges (two past pointing and two future pointing)
-    # test total vertex/edge/triangle count
+    def test_6_super_edges(self):
+        """Test that each 0-simplex is contained in 6 edges"""
+        t = generate_flat.generate_flat_2d_space_time(time_size=3, space_size=3)
+        counts = defaultdict(int)
+        for edge in t._simplices[1]:
+            b = edge.basis_list
+            counts[b[0]] += 1
+            counts[b[1]] += 1
+        # solidify the dictionary
+        counts = dict(counts)
+        for v in t._simplices[0]:
+            b = v.basis_list[0]
+            assert counts[b] == 6
+
+    def test_6_super_triangles(self):
+        """Test that each 0-simplex is contained in 6 edges"""
+        t = generate_flat.generate_flat_2d_space_time(time_size=3, space_size=3)
+        counts = defaultdict(int)
+        for tri in t._simplices[2]:
+            b = tri.basis_list
+            counts[b[0]] += 1
+            counts[b[1]] += 1
+            counts[b[2]] += 1
+        # solidify the dictionary
+        counts = dict(counts)
+        for v in t._simplices[0]:
+            b = v.basis_list[0]
+            assert counts[b] == 6
+
+    # split in to two for past and future edges?
+    def test_4_temporal_edges(self):
+        """Test that each 0-simplex is contained in 6 edges"""
+        t = generate_flat.generate_flat_2d_space_time(time_size=3, space_size=3)
+        counts = defaultdict(int)
+        for edge in t._simplices[1]:
+            b = edge.basis_list
+            if t._simplex_meta[edge]["s_type"] == [1, 1]:
+                counts[b[0]] += 1
+                counts[b[1]] += 1
+        # solidify the dictionary
+        counts = dict(counts)
+        for v in t._simplices[0]:
+            b = v.basis_list[0]
+            assert counts[b] == 4
+
+    def test_correct_size(self):
+        space_sizes_to_test = [3, 4, 5, 6]
+        time_sizes_to_test = [3, 4, 5, 6]
+        for t_size in time_sizes_to_test:
+            for x_size in space_sizes_to_test:
+                n = t_size * x_size
+                t = generate_flat.generate_flat_2d_space_time(time_size=t_size, space_size=x_size)
+                assert len(t._simplices[0]) == n
+                assert len(t._simplices[1]) == 3 * n
+
+# test total
+
+# vertex/edge/triangle count


### PR DESCRIPTION
# Description

Adds a function for generating an initial flat triangulation

# Testing

ran the test suite
added a test to make sure it outputs a triangulation

tested time scaling
![Figure_1](https://user-images.githubusercontent.com/1857496/115972460-5ba2df00-a51c-11eb-99ea-2a4a7aeb3504.png)
Which is linear as expected.
Slope may change as more meta data is added. Currently this includes all simplex types and a random dilaton value for 2-simplicies.


# Examples
```python
from cdtea import generate_flat

time_size = 10
space_size = 10
generate_flat.generate_flat_2d_space_time(time_size, space_size)
```

