### PR TITLE
Parity move

### DIFF
--- a/cdtea/generate_flat.py
+++ b/cdtea/generate_flat.py
@@ -39,7 +39,7 @@ def generate_flat_2d_space_time(time_size: int, space_size: int) -> simplicial.T
         for x in range(space_size):
             # new vertex (one added per iteration )
             i = idx(x_idx=x, t_idx=t)
-            add_simplex(i, t=t, x=x)
+            add_simplex(i, t=t, order=6)
 
             # new edges (three added per vertex)
             spatial_edge_basis = {idx(x_idx=x, t_idx=t), idx(x_idx=x + 1, t_idx=t)}

--- a/cdtea/modifications.py
+++ b/cdtea/modifications.py
@@ -1,14 +1,34 @@
 from cdtea.simplicial import Triangulation, SimplexKey, DimDSimplexKey, Dim0SimplexKey, simplex_key
 from cdtea.generate_flat import generate_flat_2d_space_time as gen
+from cdtea.tests import valid_triangulation as validity
 
 tri = gen(space_size=5, time_size=5)
 
 
 def parity_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
     overlap = k1 & k2
+    union = k1 | k2
+    non_overlap = union - overlap
+    # print(union)
     if overlap in triangulation.simplices[1]:
         s_type = triangulation.simplex_meta[overlap]["s_type"]
         if s_type == (1, 1):
+            # This is where we modify the triangulation
+            # The dim 0 simplices remain unchanged.
+
+            # the dim 1 simplices. the spatial edge is removed and replaced with another
+            triangulation.remove_simplex(overlap)
+            triangulation.add_simplex(non_overlap, s_type=(1, 1))
+
+            # the dim 2 simplices, the two associated with the overlap are removed and the two new ones added
+            triangulation.remove_simplex(k1)
+            triangulation.remove_simplex(k2)
+            overlap_list = overlap.basis_list
+            times = [triangulation.simplex_meta[b]['t'] for b in overlap_list]
+            overlap_list = [x for _, x in sorted(zip(times, overlap_list))]
+            triangulation.add_simplex(non_overlap | overlap_list[0], s_type=(1, 2))
+            triangulation.add_simplex(non_overlap | overlap_list[1], s_type=(2, 1))
+
             pass
         else:
             raise Exception("Faces are temporal neighbors not spatial neighbors")
@@ -19,3 +39,4 @@ def parity_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
 key1 = simplex_key({1, 21, 22})
 key2 = simplex_key({1, 2, 22})
 parity_move(tri, key1, key2)
+validity.is_valid(tri)

--- a/cdtea/modifications.py
+++ b/cdtea/modifications.py
@@ -1,6 +1,7 @@
 from cdtea.simplicial import Triangulation, SimplexKey, DimDSimplexKey, Dim0SimplexKey, simplex_key
 from cdtea.generate_flat import generate_flat_2d_space_time as gen
 from cdtea.tests import valid_triangulation as validity
+from cdtea.util.TimeIndex import time_sep
 
 tri = gen(space_size=5, time_size=5)
 
@@ -13,6 +14,7 @@ def parity_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
     if overlap in triangulation.simplices[1]:
         s_type = triangulation.simplex_meta[overlap]["s_type"]
         if s_type == (1, 1):
+            meta = triangulation.simplex_meta
             # This is where we modify the triangulation
             # The dim 0 simplices remain unchanged.
 
@@ -23,11 +25,14 @@ def parity_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
             # the dim 2 simplices, the two associated with the overlap are removed and the two new ones added
             triangulation.remove_simplex(k1)
             triangulation.remove_simplex(k2)
+
             overlap_list = overlap.basis_list
-            times = [triangulation.simplex_meta[b]['t'] for b in overlap_list]
-            overlap_list = [x for _, x in sorted(zip(times, overlap_list))]
-            triangulation.add_simplex(non_overlap | overlap_list[0], s_type=(1, 2))
-            triangulation.add_simplex(non_overlap | overlap_list[1], s_type=(2, 1))
+            times = [meta[b]['t'] for b in overlap_list]
+            times = {b: time_sep(min(times), meta[b]['t'], triangulation.time_size) for b in overlap_list}
+            overlap_list = sorted(overlap_list, key=lambda x: times[x])
+
+            triangulation.add_simplex(non_overlap | overlap_list[0], s_type=(2, 1))
+            triangulation.add_simplex(non_overlap | overlap_list[1], s_type=(1, 2))
 
             pass
         else:

--- a/cdtea/modifications.py
+++ b/cdtea/modifications.py
@@ -41,7 +41,59 @@ def parity_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
         raise Exception("Faces are not neighbors")
 
 
+def increase_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
+    overlap = k1 & k2
+    union = k1 | k2
+    non_overlap = union - overlap
+    # print(union)
+    if overlap in triangulation.simplices[1]:
+        s_type = triangulation.simplex_meta[overlap]["s_type"]
+        if s_type == (2, 0):
+            meta = triangulation.simplex_meta
+            # This is where we modify the triangulation
+            # The dim 0 simplices remain unchanged.
+            top = k1 - overlap
+            bottom = k2 - overlap
+            overlap_list = overlap.basis_list
+            left = overlap_list[0]
+            right = overlap_list[1]
+
+            new_node = simplex_key(triangulation.max_index)
+
+            triangulation.add_simplex(new_node, t=meta[right]['t'])
+
+            # the dim 1 simplices. the spatial edge is removed and replaced with another
+            triangulation.remove_simplex(overlap)
+
+            triangulation.add_simplex(top | new_node, s_type=(1, 1))
+            triangulation.add_simplex(bottom | new_node, s_type=(1, 1))
+
+            triangulation.add_simplex(left | new_node, s_type=(2, 0))
+            triangulation.add_simplex(right | new_node, s_type=(2, 0))
+
+            # the dim 2 simplices, the two associated with the overlap are removed and the two new ones added
+            k1_s_type = meta[k1]["s_type"]
+            k2_s_type = meta[k2]["s_type"]
+
+            triangulation.add_simplex(top | new_node | left, s_type=k1_s_type)
+            triangulation.add_simplex(top | new_node | right, s_type=k1_s_type)
+
+            triangulation.add_simplex(bottom | new_node | left, s_type=k2_s_type)
+            triangulation.add_simplex(bottom | new_node | right, s_type=k2_s_type)
+
+            triangulation.remove_simplex(k1)
+            triangulation.remove_simplex(k2)
+
+
+        else:
+            raise Exception("Faces are spatial neighbors not temporal neighbors")
+    else:
+        raise Exception("Faces are not neighbors")
+
+
 key1 = simplex_key({1, 21, 22})
 key2 = simplex_key({1, 2, 22})
-parity_move(tri, key1, key2)
+key1 = simplex_key({10, 6, 5})
+key2 = simplex_key({1, 6, 5})
+increase_move(tri, key1, key2)
 validity.is_valid(tri)

--- a/cdtea/modifications.py
+++ b/cdtea/modifications.py
@@ -138,12 +138,3 @@ def decrease_move(triangulation: Triangulation, k1: SimplexKey):
     else:
         raise Exception("vertex {} is not of order 4".format(k1))
 
-
-key1 = simplex_key({1, 21, 22})
-key2 = simplex_key({1, 2, 22})
-key1 = simplex_key({10, 6, 5})
-key2 = simplex_key({1, 6, 5})
-increase_move(tri, key1, key2)
-validity.is_valid(tri)
-decrease_move(tri, simplex_key(25))
-validity.is_valid(tri)

--- a/cdtea/modifications.py
+++ b/cdtea/modifications.py
@@ -2,11 +2,15 @@ from cdtea.simplicial import Triangulation, SimplexKey, DimDSimplexKey, Dim0Simp
 from cdtea.generate_flat import generate_flat_2d_space_time as gen
 from cdtea.tests import valid_triangulation as validity
 from cdtea.util.TimeIndex import time_sep
+from functools import reduce
 
 tri = gen(space_size=5, time_size=5)
 
 
 def parity_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
+    """
+    |/| -> |\|
+    """
     overlap = k1 & k2
     union = k1 | k2
     non_overlap = union - overlap
@@ -17,6 +21,11 @@ def parity_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
             meta = triangulation.simplex_meta
             # This is where we modify the triangulation
             # The dim 0 simplices remain unchanged.
+
+            for b in overlap:
+                meta[b]["order"] -= 1
+            for b in non_overlap:
+                meta[b]["order"] += 1
 
             # the dim 1 simplices. the spatial edge is removed and replaced with another
             triangulation.remove_simplex(overlap)
@@ -42,6 +51,10 @@ def parity_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
 
 
 def increase_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
+    """
+        /__\  ->  /|\
+        \ /       \|/
+    """
     overlap = k1 & k2
     union = k1 | k2
     non_overlap = union - overlap
@@ -60,7 +73,9 @@ def increase_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
 
             new_node = simplex_key(triangulation.max_index)
 
-            triangulation.add_simplex(new_node, t=meta[right]['t'])
+            triangulation.add_simplex(new_node, t=meta[right]['t'], order=4)
+            meta[top]["order"] += 1
+            meta[bottom]["order"] += 1
 
             # the dim 1 simplices. the spatial edge is removed and replaced with another
             triangulation.remove_simplex(overlap)
@@ -91,9 +106,44 @@ def increase_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
         raise Exception("Faces are not neighbors")
 
 
+def decrease_move(triangulation: Triangulation, k1: SimplexKey):
+    """
+             /|\   ->  /__\
+             \|/       \ /
+    """
+    meta = triangulation.simplex_meta
+
+    if meta[k1]["order"] == 4:
+        t_index = meta[k1]["t"]
+        faces = [f for f in triangulation.simplices[2] if k1 in f]
+        union = reduce(lambda x, y: x | y, faces) - k1
+        space_neighbors = [b for b in union if meta[b]["t"] == t_index]
+        spatial_edge = space_neighbors[0] | space_neighbors[1]
+
+        triangulation.add_simplex(spatial_edge, s_type=(2, 0))
+
+
+
+        for b in union - spatial_edge:
+            meta[b]["order"] -= 1
+        triangulation.remove_simplex(k1)
+        for f in faces:
+            # THIS DOUBLE ADDS SIMPLEX but because its a set it shouldn't be double counted.
+            triangulation.add_simplex((f - k1) | spatial_edge, s_type=meta[f]["s_type"])
+            triangulation.remove_simplex(f)
+
+        for v in union:
+            triangulation.remove_simplex(v | k1)
+        pass
+    else:
+        raise Exception("vertex {} is not of order 4".format(k1))
+
+
 key1 = simplex_key({1, 21, 22})
 key2 = simplex_key({1, 2, 22})
 key1 = simplex_key({10, 6, 5})
 key2 = simplex_key({1, 6, 5})
 increase_move(tri, key1, key2)
+validity.is_valid(tri)
+decrease_move(tri, simplex_key(25))
 validity.is_valid(tri)

--- a/cdtea/modifications.py
+++ b/cdtea/modifications.py
@@ -3,6 +3,7 @@ from cdtea.generate_flat import generate_flat_2d_space_time as gen
 from cdtea.tests import valid_triangulation as validity
 from cdtea.util.TimeIndex import time_sep
 from functools import reduce
+import random
 
 tri = gen(space_size=5, time_size=5)
 
@@ -40,8 +41,8 @@ def parity_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
             times = {b: time_sep(min(times), meta[b]['t'], triangulation.time_size) for b in overlap_list}
             overlap_list = sorted(overlap_list, key=lambda x: times[x])
 
-            triangulation.add_simplex(non_overlap | overlap_list[0], s_type=(2, 1))
-            triangulation.add_simplex(non_overlap | overlap_list[1], s_type=(1, 2))
+            triangulation.add_simplex(non_overlap | overlap_list[0], s_type=(2, 1), dilation = random.Random())
+            triangulation.add_simplex(non_overlap | overlap_list[1], s_type=(1, 2), dilation = random.Random())
 
             pass
         else:
@@ -90,11 +91,11 @@ def increase_move(triangulation: Triangulation, k1: SimplexKey, k2: SimplexKey):
             k1_s_type = meta[k1]["s_type"]
             k2_s_type = meta[k2]["s_type"]
 
-            triangulation.add_simplex(top | new_node | left, s_type=k1_s_type)
-            triangulation.add_simplex(top | new_node | right, s_type=k1_s_type)
+            triangulation.add_simplex(top | new_node | left, s_type=k1_s_type, dilation = random.Random())
+            triangulation.add_simplex(top | new_node | right, s_type=k1_s_type, dilation = random.Random())
 
-            triangulation.add_simplex(bottom | new_node | left, s_type=k2_s_type)
-            triangulation.add_simplex(bottom | new_node | right, s_type=k2_s_type)
+            triangulation.add_simplex(bottom | new_node | left, s_type=k2_s_type, dilation = random.Random())
+            triangulation.add_simplex(bottom | new_node | right, s_type=k2_s_type, dilation = random.Random())
 
             triangulation.remove_simplex(k1)
             triangulation.remove_simplex(k2)
@@ -129,7 +130,7 @@ def decrease_move(triangulation: Triangulation, k1: SimplexKey):
         triangulation.remove_simplex(k1)
         for f in faces:
             # THIS DOUBLE ADDS SIMPLEX but because its a set it shouldn't be double counted.
-            triangulation.add_simplex((f - k1) | spatial_edge, s_type=meta[f]["s_type"])
+            triangulation.add_simplex((f - k1) | spatial_edge, s_type=meta[f]["s_type"], dilation = random.Random())
             triangulation.remove_simplex(f)
 
         for v in union:

--- a/cdtea/simplicial.py
+++ b/cdtea/simplicial.py
@@ -119,14 +119,17 @@ class DimDSimplexKey(SimplexKey):
 
 class Triangulation:
     """Triangulation Class Stub"""
-    __slots__ = ('_simplices', '_simplex_meta', '_time_size')
+    __slots__ = ('_simplices', '_simplex_meta', '_time_size','_max_index')
 
     def __init__(self, time_size: int):
         self._simplices = collections.defaultdict(set)
         self._simplex_meta = collections.defaultdict(dict)
         self._time_size = time_size
+        self._max_index = 0
 
     def add_simplex(self, key: SimplexKey, **meta):
+        if key.dim == 0:
+            self._max_index += 1
         self._simplices[key.dim].add(key)
         self._simplex_meta[key] = meta
 
@@ -142,6 +145,10 @@ class Triangulation:
     @property
     def simplices(self):
         return self._simplices
+
+    @property
+    def max_index(self):
+        return self._max_index
 
     @property
     def simplex_meta(self):

--- a/cdtea/simplicial.py
+++ b/cdtea/simplicial.py
@@ -45,12 +45,16 @@ class SimplexKey:
             print("Equality not defined between SimplexKey and " + str(type(other)))
             return False
 
-    # this feels really dangerous, i'm just trying it out
+    # to speed up set style interactions with simplex keys
     # to define union
     def __or__(self, other):
-        new_basis = self._basis | other._basis
+        self_basis = self._basis if type(self) == DimDSimplexKey else {self}
+        other_basis = other._basis if type(other) == DimDSimplexKey else {other}
+
+        new_basis = self_basis | other_basis
+
         if len(new_basis) == 1:
-            return Dim0SimplexKey(new_basis)
+            return list(new_basis)[0]
         else:
             return DimDSimplexKey(new_basis)
 
@@ -58,9 +62,21 @@ class SimplexKey:
     def __and__(self, other):
         new_basis = self._basis & other._basis
         if len(new_basis) == 1:
-            return Dim0SimplexKey(new_basis)
+            return list(new_basis)[0]
         else:
             return DimDSimplexKey(new_basis)
+
+    # set difference
+    def __sub__(self, other):
+        self_basis = self._basis if type(self) == DimDSimplexKey else {self}
+        other_basis = other._basis if type(other) == DimDSimplexKey else {other}
+        new_basis = self_basis - other_basis
+        if len(new_basis) == 1:
+            return list(new_basis)[0]
+        else:
+            return DimDSimplexKey(new_basis)
+
+    # ------- end set operations-------
 
     def __iter__(self):  # we can return self here, because __next__ is implemented
         return iter(self._basis)
@@ -87,6 +103,9 @@ class Dim0SimplexKey(SimplexKey):
     def __init__(self, key: int):
         super().__init__(basis={key}, dim=0)
 
+    def __lt__(self, other):
+        return (self._basis < other._basis)
+
 
 class DimDSimplexKey(SimplexKey):
     """A D dimensional simplex key"""
@@ -109,7 +128,7 @@ class Triangulation:
         self._simplex_meta[key] = meta
 
     def remove_simplex(self, key: SimplexKey):
-        del self._simplices[key.dim][key]
+        self._simplices[key.dim].remove(key)
         del self._simplex_meta[key]
 
     @property

--- a/cdtea/tests/test_generate_flat.py
+++ b/cdtea/tests/test_generate_flat.py
@@ -13,6 +13,10 @@ class TestGenerateFlat:
 
         assert isinstance(t, simplicial.Triangulation)
 
+    def test_validity(self):
+        t = generate_flat.generate_flat_2d_space_time(time_size=5, space_size=5)
+        is_valid(t)
+
     def test_6_super_edges(self):
         """Test that each 0-simplex is contained in 6 edges"""
         t = generate_flat.generate_flat_2d_space_time(time_size=3, space_size=3)
@@ -66,6 +70,4 @@ class TestGenerateFlat:
                 assert len(t.simplices[0]) == n
                 assert len(t.simplices[1]) == 3 * n
 
-    def test_validity(self):
-        t = generate_flat.generate_flat_2d_space_time(time_size=5, space_size=5)
-        is_valid(t)
+

--- a/cdtea/tests/test_modifications.py
+++ b/cdtea/tests/test_modifications.py
@@ -1,0 +1,29 @@
+from cdtea import modifications
+from cdtea.simplicial import simplex_key
+from cdtea.generate_flat import generate_flat_2d_space_time
+from cdtea.tests import valid_triangulation as validity
+
+
+class TestModifications:
+
+    def test_parity(self):
+        tri = generate_flat_2d_space_time(space_size=5, time_size=5)
+        key1 = simplex_key({1, 21, 22})
+        key2 = simplex_key({1, 2, 22})
+        modifications.parity_move(tri, key1, key2)
+        validity.is_valid(tri)
+
+    def test_increase(self):
+        tri = generate_flat_2d_space_time(space_size=5, time_size=5)
+        key1 = simplex_key({10, 6, 5})
+        key2 = simplex_key({1, 6, 5})
+        modifications.increase_move(tri, key1, key2)
+        validity.is_valid(tri)
+
+    def test_decrease(self):
+        tri = generate_flat_2d_space_time(space_size=5, time_size=5)
+        key1 = simplex_key({10, 6, 5})
+        key2 = simplex_key({1, 6, 5})
+        modifications.increase_move(tri, key1, key2)
+        modifications.decrease_move(tri, simplex_key(25))
+        validity.is_valid(tri)

--- a/cdtea/tests/test_simplicial.py
+++ b/cdtea/tests/test_simplicial.py
@@ -45,3 +45,85 @@ class TestTriangulation:
         t.add_simplex(f2, dilaton=0.6)
 
         assert isinstance(t, simplicial.Triangulation)
+
+    def test_equality(self):
+        t = simplicial.Triangulation(time_size=2)
+        assert t == t
+        assert t != 7
+
+    def test_remove_simplex(self):
+        """we cant compare to a fresh triangulation becouse we are using default dict and once a value is added it remembers that there is a category for that dimension"""
+        t1 = simplicial.Triangulation(time_size=2)
+        t2 = simplicial.Triangulation(time_size=2)
+        t1.add_simplex(simplicial.simplex_key({1, 2, 3}), prop="test meta property")
+        t1.remove_simplex(simplicial.simplex_key({1, 2, 3}))
+        t2.add_simplex(simplicial.simplex_key({1, 4, 3}), prop="test meta property")
+        t2.remove_simplex(simplicial.simplex_key({1, 4, 3}))
+        assert t1 == t2
+
+
+class TestSimplexKey:
+
+    def test_create_0d(self):
+        v1 = simplicial.Dim0SimplexKey(1)
+        v2 = simplicial.Dim0SimplexKey(2)
+        v3 = simplicial.Dim0SimplexKey(2)
+        f = simplicial.DimDSimplexKey(basis={v1, v2, v3})
+
+    def test_create_Dd(self):
+        v1 = simplicial.Dim0SimplexKey(1)
+        v2 = simplicial.Dim0SimplexKey(2)
+        v3 = simplicial.Dim0SimplexKey(2)
+        f = simplicial.DimDSimplexKey(basis={v1, v2, v3})
+
+    def test_generator_function(self):
+        v1 = simplicial.Dim0SimplexKey(1)
+        v2 = simplicial.Dim0SimplexKey(2)
+        v3 = simplicial.Dim0SimplexKey(3)
+        f = simplicial.DimDSimplexKey(basis={v1, v2, v3})
+        assert simplicial.simplex_key({1, 2, 3}) == f
+        assert simplicial.simplex_key(1) == v1
+        assert simplicial.simplex_key(v1) == v1
+        assert simplicial.simplex_key([1]) == v1
+        assert simplicial.simplex_key({v1, v2, v3}) == f
+
+    def test_union(self):
+        v1 = simplicial.Dim0SimplexKey(1)
+        v2 = simplicial.Dim0SimplexKey(2)
+        v3 = simplicial.Dim0SimplexKey(3)
+        e = simplicial.DimDSimplexKey(basis={v1, v2})
+        f = simplicial.DimDSimplexKey(basis={v1, v2, v3})
+        assert v1 | v2 | v3 == f
+        assert e | v3 == f
+        assert v1 | v1 == v1
+
+    def test_intersections(self):
+        v1 = simplicial.Dim0SimplexKey(1)
+        v2 = simplicial.Dim0SimplexKey(2)
+        v3 = simplicial.Dim0SimplexKey(3)
+        e = simplicial.DimDSimplexKey(basis={v1, v2})
+        f = simplicial.DimDSimplexKey(basis={v1, v2, v3})
+        assert f & v1 == v1
+        assert e & f == e
+        assert v1 & v1 == v1
+        assert v1 & v2 == simplicial.DimDSimplexKey({})
+
+    def test_difference(self):
+        v1 = simplicial.Dim0SimplexKey(1)
+        v2 = simplicial.Dim0SimplexKey(2)
+        v3 = simplicial.Dim0SimplexKey(3)
+        e = simplicial.DimDSimplexKey(basis={v1, v2})
+        f = simplicial.DimDSimplexKey(basis={v1, v2, v3})
+        assert v1 - v1 == simplicial.DimDSimplexKey({})
+        assert f - e == v3
+        assert e - f == simplicial.DimDSimplexKey({})
+
+    def test_iter(self):
+        v1 = simplicial.Dim0SimplexKey(1)
+        v2 = simplicial.Dim0SimplexKey(2)
+        v3 = simplicial.Dim0SimplexKey(3)
+        e = simplicial.DimDSimplexKey(basis={v1, v2})
+        f = simplicial.DimDSimplexKey(basis={v1, v2, v3})
+        for b in f:
+            assert b in f
+        assert (e in f) is False

--- a/cdtea/tests/valid_triangulation.py
+++ b/cdtea/tests/valid_triangulation.py
@@ -2,6 +2,7 @@
 from cdtea import simplicial
 from collections import defaultdict
 from itertools import combinations, permutations
+from cdtea.util.TimeIndex import time_sep
 
 
 # These tests assume 1+1d with toroidal topology
@@ -120,31 +121,23 @@ def check_s_type(triangulation: simplicial.Triangulation):
     # Checks the edges
     for e in triangulation.simplices[1]:
         basis_list = e.basis_list
-        if meta[basis_list[0]]['t'] == meta[basis_list[1]]['t']:
+        dt = time_sep(meta[basis_list[0]]['t'], meta[basis_list[1]]['t'], triangulation.time_size)
+        if dt == 0:
             assert meta[e]['s_type'] == (2, 0)
-        else:
+        elif abs(dt) == 1:
             assert meta[e]['s_type'] == (1, 1)
-    #checks the triangles
+        else:
+            raise Exception("invalid edge")
+    # checks the triangles
     for f in triangulation.simplices[2]:
-        # All of this jiggery pockery is to account for trinagles that span the max time slice to the min time slice
+
         times = [meta[b]['t'] for b in f]
+        times = [time_sep(min(times), meta[b]['t'], triangulation.time_size) for b in f]
         c1 = times.count(min(times))
-        T = triangulation.time_size
-        times = [(t + T / 2) % T for t in times]
-        c2 = times.count(min(times))
-        if c1 == c2 == 2:
+        if c1 == 2:
             assert meta[f]["s_type"] == (2, 1)
-        elif c1 == c2 == 1:
+        elif c1 == 1:
             assert meta[f]["s_type"] == (1, 2)
-        elif c1 != c2:
-            times = [(t + T / 3) % T for t in times]
-            c3 = times.count(min(times))
-            if c2 == c3 == 2 or c1 == c3 == 2:
-                assert meta[f]["s_type"] == (2, 1)
-            elif c2 == c3 == 1 or c1 == c3 == 1:
-                assert meta[f]["s_type"] == (1, 2)
-            else:
-                assert False
 
 
 def is_valid(triangulation: simplicial.Triangulation):

--- a/cdtea/tests/valid_triangulation.py
+++ b/cdtea/tests/valid_triangulation.py
@@ -113,6 +113,40 @@ def vertices_have_minimum_required_connections(triangulation: simplicial.Triangu
         assert counts_past[v] > 0, "{v} has {c} past connections".format(v=v, c=counts_past[v])
 
 
+def check_s_type(triangulation: simplicial.Triangulation):
+    """Cheks the s_type of all edges and triangles"""
+    meta = triangulation.simplex_meta
+
+    # Checks the edges
+    for e in triangulation.simplices[1]:
+        basis_list = e.basis_list
+        if meta[basis_list[0]]['t'] == meta[basis_list[1]]['t']:
+            assert meta[e]['s_type'] == (2, 0)
+        else:
+            assert meta[e]['s_type'] == (1, 1)
+    #checks the triangles
+    for f in triangulation.simplices[2]:
+        # All of this jiggery pockery is to account for trinagles that span the max time slice to the min time slice
+        times = [meta[b]['t'] for b in f]
+        c1 = times.count(min(times))
+        T = triangulation.time_size
+        times = [(t + T / 2) % T for t in times]
+        c2 = times.count(min(times))
+        if c1 == c2 == 2:
+            assert meta[f]["s_type"] == (2, 1)
+        elif c1 == c2 == 1:
+            assert meta[f]["s_type"] == (1, 2)
+        elif c1 != c2:
+            times = [(t + T / 3) % T for t in times]
+            c3 = times.count(min(times))
+            if c2 == c3 == 2 or c1 == c3 == 2:
+                assert meta[f]["s_type"] == (2, 1)
+            elif c2 == c3 == 1 or c1 == c3 == 1:
+                assert meta[f]["s_type"] == (1, 2)
+            else:
+                assert False
+
+
 def is_valid(triangulation: simplicial.Triangulation):
     twice_as_many_2d_as_0d(triangulation)
     edges_imply_faces(triangulation)
@@ -121,3 +155,4 @@ def is_valid(triangulation: simplicial.Triangulation):
     faces_imply_nodes(triangulation)
     edges_dont_cross_time_slices(triangulation)
     vertices_have_minimum_required_connections(triangulation)
+    check_s_type(triangulation)

--- a/cdtea/tests/valid_triangulation.py
+++ b/cdtea/tests/valid_triangulation.py
@@ -9,8 +9,7 @@ from cdtea.util.TimeIndex import time_sep
 
 def twice_as_many_2d_as_0d(triangulation: simplicial.Triangulation):
     """For toroidal topology in 1+1d there should be twice as many faces as vertices"""
-    assert len(triangulation.simplices[0]) * 2 == len(
-        triangulation.simplices[2]), "The number of triangles was not twice the number of vertices"
+    assert len(triangulation.simplices[0]) * 2 == len(triangulation.simplices[2]), "The number of triangles was not twice the number of vertices"
 
 
 def edges_imply_faces(triangulation: simplicial.Triangulation):
@@ -138,6 +137,8 @@ def check_s_type(triangulation: simplicial.Triangulation):
             assert meta[f]["s_type"] == (2, 1)
         elif c1 == 1:
             assert meta[f]["s_type"] == (1, 2)
+
+    # Check if Dim0Simpplex order is correct
 
 
 def is_valid(triangulation: simplicial.Triangulation):

--- a/cdtea/util/TimeIndex.py
+++ b/cdtea/util/TimeIndex.py
@@ -1,0 +1,8 @@
+def time_sep(t1: int, t2: int, time_max: int):
+    """ Calculate the separation amount and direction of two time slices"""
+    i = (t1 - t2) % time_max
+    j = (t2 - t1) % time_max
+    if i < j:
+        return -i
+    if j <= i:
+        return j

--- a/cdtea/util/tests/test_time_index.py
+++ b/cdtea/util/tests/test_time_index.py
@@ -1,0 +1,12 @@
+"""Tests for EquivDict utility"""
+import collections
+
+from cdtea.util import TimeIndex
+
+
+class TestTimeIndex:
+    """Tests for TimeIndex manipulation"""
+    def test_time_sep(self):
+        assert TimeIndex.time_sep(2, 8, 10) == -4
+        assert TimeIndex.time_sep(8, 2, 10) == 4
+        assert TimeIndex.time_sep(8, 8, 10) == 0


### PR DESCRIPTION
# Description

Add moves and utilities to facilitate moves


add moves and tests for moves.

Fixes #10 poorly.

Changes:
- add set style operations to simplex keys
- make simplex keys iterable
- add increase/decrease/parity move
- add "order" param to keep track of the number of edges a vertex is connected to.


# Testing

add appropriate tests. Ran test suite.

- [x] PR Test Suite


