### PR TITLE
Add simplex equivalence

### DIFF
--- a/cdtea/simplicial.py
+++ b/cdtea/simplicial.py
@@ -4,229 +4,229 @@ References:
     [1] R. Loll, Quantum Gravity from Causal Dynamical Triangulations: A Review, Class. Quantum Grav. 37, 013002 (2020).
 """
 from __future__ import annotations
+
 import collections
-import random
-from typing import Union, Iterable
 from itertools import combinations
+from typing import Union, Iterable
+
 from cdtea.util import equivdict
 
 
-
 def simplex_key(basis: Union[int, Iterable]):
-    """
-    Generates a simplex key from an int or an iterable of ints
-    """
+	"""
+	Generates a simplex key from an int or an iterable of ints
+	"""
 
-    if isinstance(basis, int):
-        return Dim0SimplexKey(basis)
+	if isinstance(basis, int):
+		return Dim0SimplexKey(basis)
 
-    if not isinstance(basis, Iterable):
-        raise Exception("given basis must be iterable of ints or an int")
+	if not isinstance(basis, Iterable):
+		raise Exception("given basis must be iterable of ints or an int")
 
-    fixed_basis = set()
-    for b in basis:
-        if isinstance(b, Dim0SimplexKey):
-            fixed_basis.add(b)
-        elif isinstance(b, int):
-            fixed_basis.add(Dim0SimplexKey(b))
-        else:
-            raise Exception("given basis must be iterable of ints or an int")
-    # if basis is an iterable with a single item
-    if len(fixed_basis) == 1:
-        return list(fixed_basis)[0]
-    return DimDSimplexKey(fixed_basis)
+	fixed_basis = set()
+	for b in basis:
+		if isinstance(b, Dim0SimplexKey):
+			fixed_basis.add(b)
+		elif isinstance(b, int):
+			fixed_basis.add(Dim0SimplexKey(b))
+		else:
+			raise Exception("given basis must be iterable of ints or an int")
+	# if basis is an iterable with a single item
+	if len(fixed_basis) == 1:
+		return list(fixed_basis)[0]
+	return DimDSimplexKey(fixed_basis)
 
 
 class SimplexKey:
-    """A reference to a simplex"""
-    _COUNTS = collections.defaultdict(int)
-    __slots__ = ('_basis', '_dim', '_sub_keys', '_count_id')
+	"""A reference to a simplex"""
+	_COUNTS = collections.defaultdict(int)
+	__slots__ = ('_basis', '_dim', '_sub_keys', '_count_id')
 
-    def __init__(self, basis: Union[frozenset, set], dim: int = None, multi: bool = False, count_id: int = None):
-        """Create a Simplex Key
+	def __init__(self, basis: Union[frozenset, set], dim: int = None, multi: bool = False, count_id: int = None):
+		"""Create a Simplex Key
 
-        Args:
-            basis:
-                frozenset or set, the basis 0simplices
-            dim:
-                int, default None, the dimension of the new simplex
-            multi:
-                bool, default False, if True create a new copy of the simplex corresponding to the given basis. Example
-                usage is creating a multi edge, for the second edge set "multi=True".
-            count_id:
-                int, default None, used to distinguish multisimplices. Must be passed if creating a reference to a multi
-                simplex (at which point the "multi" argument will be True)
-        """
-        self._basis = frozenset(basis)
-        self._dim = dim
-        self._sub_keys = None
+		Args:
+			basis:
+				frozenset or set, the basis 0simplices
+			dim:
+				int, default None, the dimension of the new simplex
+			multi:
+				bool, default False, if True create a new copy of the simplex corresponding to the given basis. Example
+				usage is creating a multi edge, for the second edge set "multi=True".
+			count_id:
+				int, default None, used to distinguish multisimplices. Must be passed if creating a reference to a multi
+				simplex (at which point the "multi" argument will be True)
+		"""
+		self._basis = frozenset(basis)
+		self._dim = dim
+		self._sub_keys = None
 
-        if multi:
-            self._COUNTS[self._basis] += 1
-            self._count_id = self._COUNTS[self._basis]
-        else:
-            if self._COUNTS[self._basis] > 0 and count_id is None:
-                raise ValueError('Cannot create reference to multi simplex without a count_id.')
-            self._count_id = count_id
+		if multi:
+			self._COUNTS[self._basis] += 1
+			self._count_id = self._COUNTS[self._basis]
+		else:
+			if self._COUNTS[self._basis] > 0 and count_id is None:
+				raise ValueError('Cannot create reference to multi simplex without a count_id.')
+			self._count_id = count_id
 
-    def __repr__(self):
-        if self._dim == 0:
-            return '<' + str(list(self._basis)[0]) + '>'
-        return '<' + ' '.join(str(list(b._basis)[0]) for b in self._basis) + '>'
+	def __repr__(self):
+		if self._dim == 0:
+			return '<' + str(list(self._basis)[0]) + '>'
+		return '<' + ' '.join(str(list(b._basis)[0]) for b in self._basis) + '>'
 
-    def __hash__(self):
-        return hash((self._count_id, self._basis))
+	def __hash__(self):
+		return hash((self._count_id, self._basis))
 
-    def __eq__(self, other):
-        if isinstance(other, SimplexKey):
-            return self._basis == other._basis and self._count_id == other._count_id
-        # print("Equality not defined between SimplexKey and " + str(isinstance(other,
-        return False
+	def __eq__(self, other):
+		if isinstance(other, SimplexKey):
+			return self._basis == other._basis and self._count_id == other._count_id
+		# print("Equality not defined between SimplexKey and " + str(isinstance(other,
+		return False
 
-    # to speed up set style interactions with simplex keys
-    # to define union
-    def __or__(self, other):
-        self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
-        other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
+	# to speed up set style interactions with simplex keys
+	# to define union
+	def __or__(self, other):
+		self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
+		other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
 
-        new_basis = self_basis | other_basis
+		new_basis = self_basis | other_basis
 
-        if len(new_basis) == 1:
-            return list(new_basis)[0]
-        return DimDSimplexKey(new_basis)
+		if len(new_basis) == 1:
+			return list(new_basis)[0]
+		return DimDSimplexKey(new_basis)
 
-    # to define intersection
-    def __and__(self, other):
-        self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
-        other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
+	# to define intersection
+	def __and__(self, other):
+		self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
+		other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
 
-        new_basis = self_basis & other_basis
-        if len(new_basis) == 1:
-            return list(new_basis)[0]
-        return DimDSimplexKey(new_basis)
+		new_basis = self_basis & other_basis
+		if len(new_basis) == 1:
+			return list(new_basis)[0]
+		return DimDSimplexKey(new_basis)
 
-    # set difference
-    def __sub__(self, other):
-        self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
-        other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
-        new_basis = self_basis - other_basis
-        if len(new_basis) == 1:
-            return list(new_basis)[0]
-        return DimDSimplexKey(new_basis)
+	# set difference
+	def __sub__(self, other):
+		self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
+		other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
+		new_basis = self_basis - other_basis
+		if len(new_basis) == 1:
+			return list(new_basis)[0]
+		return DimDSimplexKey(new_basis)
 
-    # ------- end set operations-------
+	# ------- end set operations-------
 
-    def __iter__(self):
-        return iter(self._basis)
+	def __iter__(self):
+		return iter(self._basis)
 
-    @property
-    def basis(self):
-        return self._basis
+	@property
+	def basis(self):
+		return self._basis
 
-    @property
-    def basis_list(self):
-        return list(self._basis)
+	@property
+	def basis_list(self):
+		return list(self._basis)
 
-    @property
-    def dim(self):
-        return self._dim
+	@property
+	def dim(self):
+		return self._dim
 
-    @property
-    def sub_keys(self):
-        """get all sub-simplices of self. (excluding self)"""
-        if self._sub_keys is None:
-            self._sub_keys = set({})
-            for d in range(1, self.dim + 1):
-                combs = {simplex_key(x) for x in combinations(self.basis, d)}
-                self._sub_keys = self._sub_keys.union(combs)
-        return self._sub_keys
+	@property
+	def sub_keys(self):
+		"""get all sub-simplices of self. (excluding self)"""
+		if self._sub_keys is None:
+			self._sub_keys = set({})
+			for d in range(1, self.dim + 1):
+				combs = {simplex_key(x) for x in combinations(self.basis, d)}
+				self._sub_keys = self._sub_keys.union(combs)
+		return self._sub_keys
 
 
 class Dim0SimplexKey(SimplexKey):
-    """A zero dimensional simplex key - reference to a node"""
+	"""A zero dimensional simplex key - reference to a node"""
 
-    def __init__(self, key: int):
-        super().__init__(basis={key}, dim=0)
+	def __init__(self, key: int):
+		super().__init__(basis={key}, dim=0)
 
 
 class DimDSimplexKey(SimplexKey):
-    """A D dimensional simplex key"""
+	"""A D dimensional simplex key"""
 
-    def __init__(self, basis: Union[set[SimplexKey], frozenset[SimplexKey]], multi: bool = False, count_id: int = None):
-        super().__init__(basis=basis, dim=len(basis) - 1, multi=multi, count_id=count_id)
+	def __init__(self, basis: Union[set[SimplexKey], frozenset[SimplexKey]], multi: bool = False, count_id: int = None):
+		super().__init__(basis=basis, dim=len(basis) - 1, multi=multi, count_id=count_id)
 
 
 class Triangulation:
-    """Triangulation Class, can represent simplicial manifolds."""
-    __slots__ = ('_simplices', '_simplex_meta', '_time_size', '_max_index')
+	"""Triangulation Class, can represent simplicial manifolds."""
+	__slots__ = ('_simplices', '_simplex_meta', '_time_size', '_max_index')
 
-    def __init__(self, time_size: int):
-        self._simplices = collections.defaultdict(set)
-        self._simplex_meta = collections.defaultdict(equivdict.EquivDict)
-        self._time_size = time_size
-        self._max_index = 0
+	def __init__(self, time_size: int):
+		self._simplices = collections.defaultdict(set)
+		self._simplex_meta = collections.defaultdict(equivdict.EquivDict)
+		self._time_size = time_size
+		self._max_index = 0
 
-    def add_simplex(self, key: SimplexKey, **meta):
-        """adds a simplex to the triangulation"""
-        if key.dim == 0:
-            self._max_index += 1
-        self._simplices[key.dim].add(key)
+	def add_simplex(self, key: SimplexKey, **meta):
+		"""adds a simplex to the triangulation"""
+		if key.dim == 0:
+			self._max_index += 1
+		self._simplices[key.dim].add(key)
 
-        if key.dim != 0:
-            meta['contains'] = key.sub_keys
-        for k, v in meta.items():
-            self._simplex_meta[k][key] = v
+		if key.dim != 0:
+			meta['contains'] = key.sub_keys
+		for k, v in meta.items():
+			self._simplex_meta[k][key] = v
 
-    def remove_simplex(self, key: SimplexKey):
-        """removes a simplex from the triangulation"""
-        self._simplices[key.dim].remove(key)
-        for _, meta_k in self._simplex_meta.items():
-            if key in meta_k.keys:
-                del meta_k[key]
+	def remove_simplex(self, key: SimplexKey):
+		"""removes a simplex from the triangulation"""
+		self._simplices[key.dim].remove(key)
+		for _, meta_k in self._simplex_meta.items():
+			if key in meta_k.keys:
+				del meta_k[key]
 
-    def __eq__(self, other):
-        if isinstance(other, Triangulation):
-            same_simplices = self._simplices == other.simplices
-            same_meta = self._simplex_meta == other.simplex_meta
-            same_time_size = self.time_size == other.time_size
-            same_triangulation = same_simplices and same_meta and same_time_size
-            return same_triangulation
-        return False
+	def __eq__(self, other):
+		if isinstance(other, Triangulation):
+			same_simplices = self._simplices == other.simplices
+			same_meta = self._simplex_meta == other.simplex_meta
+			same_time_size = self.time_size == other.time_size
+			same_triangulation = same_simplices and same_meta and same_time_size
+			return same_triangulation
+		return False
 
-    # Safe access methods
-    @property
-    def simplices(self):
-        return self._simplices
+	# Safe access methods
+	@property
+	def simplices(self):
+		return self._simplices
 
-    @property
-    def max_index(self):
-        return self._max_index
+	@property
+	def max_index(self):
+		return self._max_index
 
-    @property
-    def simplex_meta(self):
-        return self._simplex_meta
+	@property
+	def simplex_meta(self):
+		return self._simplex_meta
 
-    @property
-    def time_size(self):
-        return self._time_size
+	@property
+	def time_size(self):
+		return self._time_size
 
-    # quick semantic access to triangulation elements and properties
-    @property
-    def nodes(self):
-        return self._simplices[0]
+	# quick semantic access to triangulation elements and properties
+	@property
+	def nodes(self):
+		return self._simplices[0]
 
-    @property
-    def edges(self):
-        return self._simplices[1]
+	@property
+	def edges(self):
+		return self._simplices[1]
 
-    @property
-    def faces(self):
-        return self._simplices[2]
+	@property
+	def faces(self):
+		return self._simplices[2]
 
-    @property
-    def spatial_edges(self):
-        return self._simplex_meta["s_type"].dual[(2, 0)]
+	@property
+	def spatial_edges(self):
+		return self._simplex_meta["s_type"].dual[(2, 0)]
 
-    @property
-    def rank_4_nodes(self):
-        return self._simplex_meta["order"].dual[4]
+	@property
+	def rank_4_nodes(self):
+		return self._simplex_meta["order"].dual[4]

--- a/cdtea/simplicial.py
+++ b/cdtea/simplicial.py
@@ -13,220 +13,220 @@ from cdtea.util import equivdict
 
 
 def simplex_key(basis: Union[int, Iterable]):
-	"""
-	Generates a simplex key from an int or an iterable of ints
-	"""
+    """
+    Generates a simplex key from an int or an iterable of ints
+    """
 
-	if isinstance(basis, int):
-		return Dim0SimplexKey(basis)
+    if isinstance(basis, int):
+        return Dim0SimplexKey(basis)
 
-	if not isinstance(basis, Iterable):
-		raise Exception("given basis must be iterable of ints or an int")
+    if not isinstance(basis, Iterable):
+        raise Exception("given basis must be iterable of ints or an int")
 
-	fixed_basis = set()
-	for b in basis:
-		if isinstance(b, Dim0SimplexKey):
-			fixed_basis.add(b)
-		elif isinstance(b, int):
-			fixed_basis.add(Dim0SimplexKey(b))
-		else:
-			raise Exception("given basis must be iterable of ints or an int")
-	# if basis is an iterable with a single item
-	if len(fixed_basis) == 1:
-		return list(fixed_basis)[0]
-	return DimDSimplexKey(fixed_basis)
+    fixed_basis = set()
+    for b in basis:
+        if isinstance(b, Dim0SimplexKey):
+            fixed_basis.add(b)
+        elif isinstance(b, int):
+            fixed_basis.add(Dim0SimplexKey(b))
+        else:
+            raise Exception("given basis must be iterable of ints or an int")
+    # if basis is an iterable with a single item
+    if len(fixed_basis) == 1:
+        return list(fixed_basis)[0]
+    return DimDSimplexKey(fixed_basis)
 
 
 class SimplexKey:
-	"""A reference to a simplex"""
-	_COUNTS = collections.defaultdict(int)
-	__slots__ = ('_basis', '_dim', '_sub_keys', '_count_id')
+    """A reference to a simplex"""
+    _COUNTS = collections.defaultdict(int)
+    __slots__ = ('_basis', '_dim', '_sub_keys', '_count_id')
 
-	def __init__(self, basis: Union[frozenset, set], dim: int = None, multi: bool = False, count_id: int = None):
-		"""Create a Simplex Key
+    def __init__(self, basis: Union[frozenset, set], dim: int = None, multi: bool = False, count_id: int = None):
+        """Create a Simplex Key
 
-		Args:
-			basis:
-				frozenset or set, the basis 0simplices
-			dim:
-				int, default None, the dimension of the new simplex
-			multi:
-				bool, default False, if True create a new copy of the simplex corresponding to the given basis. Example
-				usage is creating a multi edge, for the second edge set "multi=True".
-			count_id:
-				int, default None, used to distinguish multisimplices. Must be passed if creating a reference to a multi
-				simplex (at which point the "multi" argument will be True)
-		"""
-		self._basis = frozenset(basis)
-		self._dim = dim
-		self._sub_keys = None
+        Args:
+            basis:
+                frozenset or set, the basis 0simplices
+            dim:
+                int, default None, the dimension of the new simplex
+            multi:
+                bool, default False, if True create a new copy of the simplex corresponding to the given basis. Example
+                usage is creating a multi edge, for the second edge set "multi=True".
+            count_id:
+                int, default None, used to distinguish multisimplices. Must be passed if creating a reference to a multi
+                simplex (at which point the "multi" argument will be True)
+        """
+        self._basis = frozenset(basis)
+        self._dim = dim
+        self._sub_keys = None
 
-		if multi:
-			self._COUNTS[self._basis] += 1
-			self._count_id = self._COUNTS[self._basis]
-		else:
-			if self._COUNTS[self._basis] > 0 and count_id is None:
-				raise ValueError('Cannot create reference to multi simplex without a count_id.')
-			self._count_id = count_id
+        if multi:
+            self._COUNTS[self._basis] += 1
+            self._count_id = self._COUNTS[self._basis]
+        else:
+            if self._COUNTS[self._basis] > 0 and count_id is None:
+                raise ValueError('Cannot create reference to multi simplex without a count_id.')
+            self._count_id = count_id
 
-	def __repr__(self):
-		if self._dim == 0:
-			return '<' + str(list(self._basis)[0]) + '>'
-		return '<' + ' '.join(str(list(b._basis)[0]) for b in self._basis) + '>'
+    def __repr__(self):
+        if self._dim == 0:
+            return '<' + str(list(self._basis)[0]) + '>'
+        return '<' + ' '.join(str(list(b._basis)[0]) for b in self._basis) + '>'
 
-	def __hash__(self):
-		return hash((self._count_id, self._basis))
+    def __hash__(self):
+        return hash((self._count_id, self._basis))
 
-	def __eq__(self, other):
-		if isinstance(other, SimplexKey):
-			return self._basis == other._basis and self._count_id == other._count_id
-		# print("Equality not defined between SimplexKey and " + str(isinstance(other,
-		return False
+    def __eq__(self, other):
+        if isinstance(other, SimplexKey):
+            return self._basis == other._basis and self._count_id == other._count_id
+        # print("Equality not defined between SimplexKey and " + str(isinstance(other,
+        return False
 
-	# to speed up set style interactions with simplex keys
-	# to define union
-	def __or__(self, other):
-		self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
-		other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
+    # to speed up set style interactions with simplex keys
+    # to define union
+    def __or__(self, other):
+        self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
+        other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
 
-		new_basis = self_basis | other_basis
+        new_basis = self_basis | other_basis
 
-		if len(new_basis) == 1:
-			return list(new_basis)[0]
-		return DimDSimplexKey(new_basis)
+        if len(new_basis) == 1:
+            return list(new_basis)[0]
+        return DimDSimplexKey(new_basis)
 
-	# to define intersection
-	def __and__(self, other):
-		self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
-		other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
+    # to define intersection
+    def __and__(self, other):
+        self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
+        other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
 
-		new_basis = self_basis & other_basis
-		if len(new_basis) == 1:
-			return list(new_basis)[0]
-		return DimDSimplexKey(new_basis)
+        new_basis = self_basis & other_basis
+        if len(new_basis) == 1:
+            return list(new_basis)[0]
+        return DimDSimplexKey(new_basis)
 
-	# set difference
-	def __sub__(self, other):
-		self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
-		other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
-		new_basis = self_basis - other_basis
-		if len(new_basis) == 1:
-			return list(new_basis)[0]
-		return DimDSimplexKey(new_basis)
+    # set difference
+    def __sub__(self, other):
+        self_basis = self._basis if isinstance(self, DimDSimplexKey) else {self}
+        other_basis = other._basis if isinstance(other, DimDSimplexKey) else {other}
+        new_basis = self_basis - other_basis
+        if len(new_basis) == 1:
+            return list(new_basis)[0]
+        return DimDSimplexKey(new_basis)
 
-	# ------- end set operations-------
+    # ------- end set operations-------
 
-	def __iter__(self):
-		return iter(self._basis)
+    def __iter__(self):
+        return iter(self._basis)
 
-	@property
-	def basis(self):
-		return self._basis
+    @property
+    def basis(self):
+        return self._basis
 
-	@property
-	def basis_list(self):
-		return list(self._basis)
+    @property
+    def basis_list(self):
+        return list(self._basis)
 
-	@property
-	def dim(self):
-		return self._dim
+    @property
+    def dim(self):
+        return self._dim
 
-	@property
-	def sub_keys(self):
-		"""get all sub-simplices of self. (excluding self)"""
-		if self._sub_keys is None:
-			self._sub_keys = set({})
-			for d in range(1, self.dim + 1):
-				combs = {simplex_key(x) for x in combinations(self.basis, d)}
-				self._sub_keys = self._sub_keys.union(combs)
-		return self._sub_keys
+    @property
+    def sub_keys(self):
+        """get all sub-simplices of self. (excluding self)"""
+        if self._sub_keys is None:
+            self._sub_keys = set({})
+            for d in range(1, self.dim + 1):
+                combs = {simplex_key(x) for x in combinations(self.basis, d)}
+                self._sub_keys = self._sub_keys.union(combs)
+        return self._sub_keys
 
 
 class Dim0SimplexKey(SimplexKey):
-	"""A zero dimensional simplex key - reference to a node"""
+    """A zero dimensional simplex key - reference to a node"""
 
-	def __init__(self, key: int):
-		super().__init__(basis={key}, dim=0)
+    def __init__(self, key: int):
+        super().__init__(basis={key}, dim=0)
 
 
 class DimDSimplexKey(SimplexKey):
-	"""A D dimensional simplex key"""
+    """A D dimensional simplex key"""
 
-	def __init__(self, basis: Union[set[SimplexKey], frozenset[SimplexKey]], multi: bool = False, count_id: int = None):
-		super().__init__(basis=basis, dim=len(basis) - 1, multi=multi, count_id=count_id)
+    def __init__(self, basis: Union[set[SimplexKey], frozenset[SimplexKey]], multi: bool = False, count_id: int = None):
+        super().__init__(basis=basis, dim=len(basis) - 1, multi=multi, count_id=count_id)
 
 
 class Triangulation:
-	"""Triangulation Class, can represent simplicial manifolds."""
-	__slots__ = ('_simplices', '_simplex_meta', '_time_size', '_max_index')
+    """Triangulation Class, can represent simplicial manifolds."""
+    __slots__ = ('_simplices', '_simplex_meta', '_time_size', '_max_index')
 
-	def __init__(self, time_size: int):
-		self._simplices = collections.defaultdict(set)
-		self._simplex_meta = collections.defaultdict(equivdict.EquivDict)
-		self._time_size = time_size
-		self._max_index = 0
+    def __init__(self, time_size: int):
+        self._simplices = collections.defaultdict(set)
+        self._simplex_meta = collections.defaultdict(equivdict.EquivDict)
+        self._time_size = time_size
+        self._max_index = 0
 
-	def add_simplex(self, key: SimplexKey, **meta):
-		"""adds a simplex to the triangulation"""
-		if key.dim == 0:
-			self._max_index += 1
-		self._simplices[key.dim].add(key)
+    def add_simplex(self, key: SimplexKey, **meta):
+        """adds a simplex to the triangulation"""
+        if key.dim == 0:
+            self._max_index += 1
+        self._simplices[key.dim].add(key)
 
-		if key.dim != 0:
-			meta['contains'] = key.sub_keys
-		for k, v in meta.items():
-			self._simplex_meta[k][key] = v
+        if key.dim != 0:
+            meta['contains'] = key.sub_keys
+        for k, v in meta.items():
+            self._simplex_meta[k][key] = v
 
-	def remove_simplex(self, key: SimplexKey):
-		"""removes a simplex from the triangulation"""
-		self._simplices[key.dim].remove(key)
-		for _, meta_k in self._simplex_meta.items():
-			if key in meta_k.keys:
-				del meta_k[key]
+    def remove_simplex(self, key: SimplexKey):
+        """removes a simplex from the triangulation"""
+        self._simplices[key.dim].remove(key)
+        for _, meta_k in self._simplex_meta.items():
+            if key in meta_k.keys:
+                del meta_k[key]
 
-	def __eq__(self, other):
-		if isinstance(other, Triangulation):
-			same_simplices = self._simplices == other.simplices
-			same_meta = self._simplex_meta == other.simplex_meta
-			same_time_size = self.time_size == other.time_size
-			same_triangulation = same_simplices and same_meta and same_time_size
-			return same_triangulation
-		return False
+    def __eq__(self, other):
+        if isinstance(other, Triangulation):
+            same_simplices = self._simplices == other.simplices
+            same_meta = self._simplex_meta == other.simplex_meta
+            same_time_size = self.time_size == other.time_size
+            same_triangulation = same_simplices and same_meta and same_time_size
+            return same_triangulation
+        return False
 
-	# Safe access methods
-	@property
-	def simplices(self):
-		return self._simplices
+    # Safe access methods
+    @property
+    def simplices(self):
+        return self._simplices
 
-	@property
-	def max_index(self):
-		return self._max_index
+    @property
+    def max_index(self):
+        return self._max_index
 
-	@property
-	def simplex_meta(self):
-		return self._simplex_meta
+    @property
+    def simplex_meta(self):
+        return self._simplex_meta
 
-	@property
-	def time_size(self):
-		return self._time_size
+    @property
+    def time_size(self):
+        return self._time_size
 
-	# quick semantic access to triangulation elements and properties
-	@property
-	def nodes(self):
-		return self._simplices[0]
+    # quick semantic access to triangulation elements and properties
+    @property
+    def nodes(self):
+        return self._simplices[0]
 
-	@property
-	def edges(self):
-		return self._simplices[1]
+    @property
+    def edges(self):
+        return self._simplices[1]
 
-	@property
-	def faces(self):
-		return self._simplices[2]
+    @property
+    def faces(self):
+        return self._simplices[2]
 
-	@property
-	def spatial_edges(self):
-		return self._simplex_meta["s_type"].dual[(2, 0)]
+    @property
+    def spatial_edges(self):
+        return self._simplex_meta["s_type"].dual[(2, 0)]
 
-	@property
-	def rank_4_nodes(self):
-		return self._simplex_meta["order"].dual[4]
+    @property
+    def rank_4_nodes(self):
+        return self._simplex_meta["order"].dual[4]

--- a/cdtea/simplicial.py
+++ b/cdtea/simplicial.py
@@ -131,6 +131,11 @@ class SimplexKey:
     def dim(self):
         return self._dim
 
+    @classmethod
+    def flush_counts(cls):
+        """Flush Counts"""
+        cls._COUNTS = collections.defaultdict(int)
+
     @property
     def sub_keys(self):
         """get all sub-simplices of self. (excluding self)"""

--- a/cdtea/simplicial.py
+++ b/cdtea/simplicial.py
@@ -5,6 +5,7 @@ References:
 """
 from __future__ import annotations
 import collections
+import random
 from typing import Union, Iterable
 from itertools import combinations
 from cdtea.util import equivdict
@@ -38,17 +39,21 @@ def simplex_key(basis: Union[int, Iterable]):
 
 class SimplexKey:
     """A reference to a simplex"""
-    __slots__ = ('_basis', '_dim', '_sub_keys')
+    __slots__ = ('_basis', '_dim', '_sub_keys', '_unique_salt')
 
     def __init__(self, basis: Union[frozenset, set], dim: int = None):
         self._basis = frozenset(basis)
         self._dim = dim
         self._sub_keys = None
+        self._unique_salt = None if dim  == 0 else 'ASDHUIGY&T@!*EDIOJ' + str(random.randint(0, 1000000))
 
     def __repr__(self):
         if self._dim == 0:
             return '<' + str(list(self._basis)[0]) + '>'
         return '<' + ' '.join(str(list(b._basis)[0]) for b in self._basis) + '>'
+
+    def __hash__(self):
+        return hash((self._unique_salt, self._basis))
 
     def __eq__(self, other):
         if isinstance(other, SimplexKey):
@@ -91,9 +96,6 @@ class SimplexKey:
 
     def __iter__(self):
         return iter(self._basis)
-
-    def __hash__(self):
-        return hash(self._basis)
 
     @property
     def basis(self):

--- a/cdtea/tests/admin.py
+++ b/cdtea/tests/admin.py
@@ -1,0 +1,31 @@
+"""Test harness utilities
+"""
+import functools
+import inspect
+
+from cdtea import simplicial
+
+
+def _clean_scope():
+    """Utility for cleaning test scope"""
+    simplicial.SimplexKey.flush_counts()
+
+
+def clean_scope(f):
+    """Decorator for cleaning test scope"""
+
+    @functools.wraps(f)
+    def new(*args, **kwargs):
+        """New function"""
+        _clean_scope()
+        return f(*args, **kwargs)
+
+    return new
+
+
+class CleanScope:
+    """Clean scope class"""
+
+    def setup_method(self):
+        """please work"""
+        _clean_scope()

--- a/cdtea/tests/admin.py
+++ b/cdtea/tests/admin.py
@@ -1,7 +1,6 @@
 """Test harness utilities
 """
 import functools
-import inspect
 
 from cdtea import simplicial
 

--- a/cdtea/tests/test_modifications.py
+++ b/cdtea/tests/test_modifications.py
@@ -3,10 +3,10 @@ import pytest
 from cdtea import modifications
 from cdtea.simplicial import simplex_key
 from cdtea.generate_flat import generate_flat_2d_space_time
-from cdtea.tests import valid_triangulation as validity
+from cdtea.tests import valid_triangulation as validity, admin
 
 
-class TestModifications:
+class TestModifications(admin.CleanScope):
     """Tests the different moves that can be done to a triangulation"""
 
     def test_parity(self):

--- a/cdtea/tests/test_simplicial.py
+++ b/cdtea/tests/test_simplicial.py
@@ -71,7 +71,9 @@ class TestTriangulation:
         tri = simplicial.Triangulation(time_size=2)
         tri.add_simplex(s, prop="test meta property")
         k = simplicial.simplex_key
-        assert tri.simplex_meta['contains'][s] == {k({1}), k({2}), k({3}), k({1, 2}), k({1, 3}), k({2, 3})}
+        v1, v2, v3 = s.basis_list
+        expected = {v1, v2, v3, k({v1, v2}), k({v1, v3}), k({v2, v3})}
+        assert tri.simplex_meta['contains'][s] == expected
 
     def test_rank_4(self):
         """test that the rank_4_nodes method gives the correct output"""
@@ -193,13 +195,14 @@ class TestSimplexKey:
         v2 = simplicial.Dim0SimplexKey(1)
         assert v1 is v1
         assert v1 is not v2
-        assert hash(v1) == hash(v2) # Hashes are equivalent for 0-simplices
+        assert hash(v1) == hash(v2)  # Hashes are equivalent for 0-simplices
 
         v3 = simplicial.Dim0SimplexKey(3)
         l1 = simplicial.simplex_key({v1, v3})
         l2 = simplicial.simplex_key({v1, v3})
         assert l1 is l1
         assert hash(l1) == hash(l1)
+        assert l1 == l2
         assert hash(l1) != hash(l2)
 
     def test_compound_equality(self):
@@ -209,3 +212,7 @@ class TestSimplexKey:
         compound = simplicial.DimDSimplexKey(basis={v1, v2, v3})
         direct = simplicial.simplex_key({1, 2, 3})
         assert compound == direct
+
+    def test_recursive_equality(self):
+        f = simplicial.Dim0SimplexKey({1, 2, 3})
+        assert f.sub_keys == f.sub_keys

--- a/cdtea/tests/test_simplicial.py
+++ b/cdtea/tests/test_simplicial.py
@@ -3,8 +3,10 @@
 from cdtea import simplicial
 import pytest
 
+from cdtea.tests import admin
 
-class TestTriangulation:
+
+class TestTriangulation(admin.CleanScope):
     """Tests for the Triangulation Class"""
 
     def test_create(self):
@@ -101,7 +103,7 @@ class TestTriangulation:
         assert tri.spatial_edges == {e1}
 
 
-class TestSimplexKey:
+class TestSimplexKey(admin.CleanScope):
     """Tests for the SimplexKey Classes"""
 
     def test_create_dim_0_simplex_key(self):
@@ -229,7 +231,7 @@ class TestSimplexKey:
         assert f.sub_keys == f.sub_keys
 
 
-class TestMultiSimplices:
+class TestMultiSimplices(admin.CleanScope):
     """Test group for multi simplices"""
 
     def test_multi_edge_equivalence(self):

--- a/cdtea/tests/test_simplicial.py
+++ b/cdtea/tests/test_simplicial.py
@@ -198,12 +198,13 @@ class TestSimplexKey:
         assert hash(v1) == hash(v2)  # Hashes are equivalent for 0-simplices
 
         v3 = simplicial.Dim0SimplexKey(3)
+        # Assume you want to reference existing edge
         l1 = simplicial.simplex_key({v1, v3})
         l2 = simplicial.simplex_key({v1, v3})
         assert l1 is l1
         assert hash(l1) == hash(l1)
         assert l1 == l2
-        assert hash(l1) != hash(l2)
+        assert hash(l1) == hash(l2)
 
     def test_compound_equality(self):
         v1 = simplicial.Dim0SimplexKey(1)
@@ -214,5 +215,34 @@ class TestSimplexKey:
         assert compound == direct
 
     def test_recursive_equality(self):
-        f = simplicial.Dim0SimplexKey({1, 2, 3})
+        v1 = simplicial.Dim0SimplexKey(10)
+        v2 = simplicial.Dim0SimplexKey(20)
+        v3 = simplicial.Dim0SimplexKey(30)
+        f = simplicial.DimDSimplexKey({v1, v2, v3})
         assert f.sub_keys == f.sub_keys
+
+
+class TestMultiSimplices:
+    """Test group for multi simplices"""
+
+    def test_multi_edge_equivalence(self):
+        v1 = simplicial.Dim0SimplexKey(1)
+        v2 = simplicial.Dim0SimplexKey(2)
+        l1 = simplicial.DimDSimplexKey({v1, v2}, multi=False)
+        l2 = simplicial.DimDSimplexKey({v1, v2}, multi=True)
+        assert l1 != l2
+
+    def test_reference_multi(self):
+        v1 = simplicial.Dim0SimplexKey(3)
+        v2 = simplicial.Dim0SimplexKey(4)
+        l1 = simplicial.DimDSimplexKey({v1, v2}, multi=False)
+        l2 = simplicial.DimDSimplexKey({v1, v2}, multi=True)
+
+        # New reference to existing edge
+        with pytest.raises(ValueError):
+            l2_prime = simplicial.DimDSimplexKey({v1, v2})
+
+        # Properly reference to existing edge
+        l2_prime = simplicial.DimDSimplexKey({v1, v2}, multi=False, count_id=1)
+        assert isinstance(l2_prime, simplicial.SimplexKey)
+

--- a/cdtea/tests/test_simplicial.py
+++ b/cdtea/tests/test_simplicial.py
@@ -1,8 +1,8 @@
 """Tests for the simplicial module"""
 
-from cdtea import simplicial
 import pytest
 
+from cdtea import simplicial
 from cdtea.tests import admin
 
 

--- a/cdtea/tests/test_simplicial.py
+++ b/cdtea/tests/test_simplicial.py
@@ -254,4 +254,3 @@ class TestMultiSimplices:
         # Properly reference to existing edge
         l2_prime = simplicial.DimDSimplexKey({v1, v2}, multi=False, count_id=1)
         assert isinstance(l2_prime, simplicial.SimplexKey)
-

--- a/cdtea/tests/test_simplicial.py
+++ b/cdtea/tests/test_simplicial.py
@@ -180,10 +180,32 @@ class TestSimplexKey:
         str(f)
         assert str(v1) == "<1>"
 
-    def test_eq(self):
+    def test_equality(self):
         v1 = simplicial.Dim0SimplexKey(1)
         v2 = simplicial.Dim0SimplexKey(1)
         v3 = simplicial.Dim0SimplexKey(3)
         assert v1 == v2
         assert v1 != v3
         assert v1 != "cat"
+
+    def test_equivalence(self):
+        v1 = simplicial.Dim0SimplexKey(1)
+        v2 = simplicial.Dim0SimplexKey(1)
+        assert v1 is v1
+        assert v1 is not v2
+        assert hash(v1) == hash(v2) # Hashes are equivalent for 0-simplices
+
+        v3 = simplicial.Dim0SimplexKey(3)
+        l1 = simplicial.simplex_key({v1, v3})
+        l2 = simplicial.simplex_key({v1, v3})
+        assert l1 is l1
+        assert hash(l1) == hash(l1)
+        assert hash(l1) != hash(l2)
+
+    def test_compound_equality(self):
+        v1 = simplicial.Dim0SimplexKey(1)
+        v2 = simplicial.Dim0SimplexKey(2)
+        v3 = simplicial.Dim0SimplexKey(3)
+        compound = simplicial.DimDSimplexKey(basis={v1, v2, v3})
+        direct = simplicial.simplex_key({1, 2, 3})
+        assert compound == direct

--- a/cdtea/tests/test_simplicial.py
+++ b/cdtea/tests/test_simplicial.py
@@ -132,6 +132,7 @@ class TestSimplexKey:
             simplicial.simplex_key("cats")
 
     def test_union(self):
+        """test union"""
         v1 = simplicial.Dim0SimplexKey(1)
         v2 = simplicial.Dim0SimplexKey(2)
         v3 = simplicial.Dim0SimplexKey(3)
@@ -142,6 +143,7 @@ class TestSimplexKey:
         assert v1 | v1 == v1
 
     def test_intersections(self):
+        """test intersections"""
         v1 = simplicial.Dim0SimplexKey(1)
         v2 = simplicial.Dim0SimplexKey(2)
         v3 = simplicial.Dim0SimplexKey(3)
@@ -153,6 +155,7 @@ class TestSimplexKey:
         assert v1 & v2 == simplicial.DimDSimplexKey({})
 
     def test_difference(self):
+        """test difference"""
         v1 = simplicial.Dim0SimplexKey(1)
         v2 = simplicial.Dim0SimplexKey(2)
         v3 = simplicial.Dim0SimplexKey(3)
@@ -163,6 +166,7 @@ class TestSimplexKey:
         assert e - f == simplicial.DimDSimplexKey({})
 
     def test_iter(self):
+        """test iter"""
         v1 = simplicial.Dim0SimplexKey(1)
         v2 = simplicial.Dim0SimplexKey(2)
         v3 = simplicial.Dim0SimplexKey(3)
@@ -173,6 +177,7 @@ class TestSimplexKey:
         assert (e in f) is False
 
     def test_repr(self):
+        """test repr"""
         v1 = simplicial.Dim0SimplexKey(1)
         v2 = simplicial.Dim0SimplexKey(2)
         v3 = simplicial.Dim0SimplexKey(3)
@@ -183,6 +188,7 @@ class TestSimplexKey:
         assert str(v1) == "<1>"
 
     def test_equality(self):
+        """test equality"""
         v1 = simplicial.Dim0SimplexKey(1)
         v2 = simplicial.Dim0SimplexKey(1)
         v3 = simplicial.Dim0SimplexKey(3)
@@ -191,9 +197,9 @@ class TestSimplexKey:
         assert v1 != "cat"
 
     def test_equivalence(self):
+        """test union"""
         v1 = simplicial.Dim0SimplexKey(1)
         v2 = simplicial.Dim0SimplexKey(1)
-        assert v1 is v1
         assert v1 is not v2
         assert hash(v1) == hash(v2)  # Hashes are equivalent for 0-simplices
 
@@ -201,12 +207,12 @@ class TestSimplexKey:
         # Assume you want to reference existing edge
         l1 = simplicial.simplex_key({v1, v3})
         l2 = simplicial.simplex_key({v1, v3})
-        assert l1 is l1
         assert hash(l1) == hash(l1)
         assert l1 == l2
         assert hash(l1) == hash(l2)
 
     def test_compound_equality(self):
+        """test compound equality"""
         v1 = simplicial.Dim0SimplexKey(1)
         v2 = simplicial.Dim0SimplexKey(2)
         v3 = simplicial.Dim0SimplexKey(3)
@@ -215,6 +221,7 @@ class TestSimplexKey:
         assert compound == direct
 
     def test_recursive_equality(self):
+        """test recursive equality"""
         v1 = simplicial.Dim0SimplexKey(10)
         v2 = simplicial.Dim0SimplexKey(20)
         v3 = simplicial.Dim0SimplexKey(30)
@@ -226,6 +233,7 @@ class TestMultiSimplices:
     """Test group for multi simplices"""
 
     def test_multi_edge_equivalence(self):
+        """test multi edge"""
         v1 = simplicial.Dim0SimplexKey(1)
         v2 = simplicial.Dim0SimplexKey(2)
         l1 = simplicial.DimDSimplexKey({v1, v2}, multi=False)
@@ -233,6 +241,7 @@ class TestMultiSimplices:
         assert l1 != l2
 
     def test_reference_multi(self):
+        """test union"""
         v1 = simplicial.Dim0SimplexKey(3)
         v2 = simplicial.Dim0SimplexKey(4)
         l1 = simplicial.DimDSimplexKey({v1, v2}, multi=False)

--- a/cdtea/tests/test_simplicial.py
+++ b/cdtea/tests/test_simplicial.py
@@ -244,12 +244,12 @@ class TestMultiSimplices:
         """test union"""
         v1 = simplicial.Dim0SimplexKey(3)
         v2 = simplicial.Dim0SimplexKey(4)
-        l1 = simplicial.DimDSimplexKey({v1, v2}, multi=False)
-        l2 = simplicial.DimDSimplexKey({v1, v2}, multi=True)
+        simplicial.DimDSimplexKey({v1, v2}, multi=False)
+        simplicial.DimDSimplexKey({v1, v2}, multi=True)
 
         # New reference to existing edge
         with pytest.raises(ValueError):
-            l2_prime = simplicial.DimDSimplexKey({v1, v2})
+            simplicial.DimDSimplexKey({v1, v2})
 
         # Properly reference to existing edge
         l2_prime = simplicial.DimDSimplexKey({v1, v2}, multi=False, count_id=1)

--- a/cdtea/util/tests/test_triangulation_utils.py
+++ b/cdtea/util/tests/test_triangulation_utils.py
@@ -4,13 +4,14 @@ from collections import defaultdict
 import numpy as np
 import pytest
 from cdtea.generate_flat import generate_flat_2d_space_time
+from cdtea.tests import admin
 from cdtea.util import triangulation_utils as Ordering
 from cdtea.simplicial import simplex_key
 
 my_list = [1, 2, 3, 4]
 
 
-class TestOrdering:
+class TestOrdering(admin.CleanScope):
     "test methods for ordering nodes in a triangulation"
 
     def test_get_layer(self):


### PR DESCRIPTION
# Description

To allow for multi-edges (and $d>0$ multi-simplices) we change the meaning of the hash to that of *equivalence*, not the looser criterion of *equality*. Each $d>0$ simplex will now be assigned a random salt upon instantiation that is injected into the hash message, ensuring that the digest is (very probably) unique. Since we use set operations (which rely on hash equivalence), this will permit multi edges as valid collections.

Fixes # (issue)

Changes:
- reimplements the `__hash__` method of the `SimplexKey` class to add random salt for $d>0$ simplices. The salt is an attribute of the instance, and therefore we preserve the reflexivity of the hash, e.g. `hash(x) == hash(x)`

# Testing

- [ ] PR Test Suite

# Examples

This example shows that the hash of a $d=0$ simplex is identical, but that simplices with a common basis are only _equal_, not _equivalent_ (hash equality).

```python
# Create some simplices
v1 = simplicial.Dim0SimplexKey(1)
v2 = simplicial.Dim0SimplexKey(1)
v3 = simplicial.Dim0SimplexKey(3)
l1 = simplicial.simplex_key({v1, v3})
l2 = simplicial.simplex_key({v1, v3})

# Hashes are equivalent for 0-simplices
hash(v1) == hash(v2) 

 # reflexivity preserved
assert hash(l1) == hash(l1)

# equal but not equivalent
assert l1 == l2
assert hash(l1) != hash(l2) 
```

